### PR TITLE
#2: 태그 저장 Repository 개발

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,12 +37,14 @@ dependencies {
 	// spring ai
 	implementation("org.springframework.ai:spring-ai-transformers-spring-boot-starter:1.0.0-SNAPSHOT")
 
+	// kotlin-logging
+	implementation("io.github.oshai:kotlin-logging-jvm:5.1.1")
 
 	annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
-
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
-	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
+
 	// kotest
+	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
 	testImplementation("io.kotest:kotest-runner-junit5:5.4.2")
 	testImplementation("io.kotest:kotest-assertions-core:5.4.2")
 	testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.2")

--- a/src/main/kotlin/zzibu/jeho/tagify/TagifyApplication.kt
+++ b/src/main/kotlin/zzibu/jeho/tagify/TagifyApplication.kt
@@ -2,8 +2,10 @@ package zzibu.jeho.tagify
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.data.elasticsearch.config.EnableElasticsearchAuditing
 
 @SpringBootApplication
+@EnableElasticsearchAuditing
 class TagifyApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/zzibu/jeho/tagify/entity/TagInfo.kt
+++ b/src/main/kotlin/zzibu/jeho/tagify/entity/TagInfo.kt
@@ -1,0 +1,21 @@
+package zzibu.jeho.tagify.entity
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.elasticsearch.annotations.DateFormat
+import org.springframework.data.elasticsearch.annotations.Document
+import org.springframework.data.elasticsearch.annotations.Field
+import org.springframework.data.elasticsearch.annotations.FieldType
+import java.time.LocalDateTime
+
+@Document(indexName = "tags")
+data class TagInfo(
+    @Id
+    val id: String? = null,
+    val name: String,
+    val url: String,
+    val owner: String,
+    @CreatedDate
+    @Field(type = FieldType.Date, format = [DateFormat.date_hour_minute_second])
+    val uploadDate: LocalDateTime? = null,
+)

--- a/src/main/kotlin/zzibu/jeho/tagify/repository/TagRepository.kt
+++ b/src/main/kotlin/zzibu/jeho/tagify/repository/TagRepository.kt
@@ -1,0 +1,10 @@
+package zzibu.jeho.tagify.repository
+
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository
+import zzibu.jeho.tagify.entity.TagInfo
+import java.util.*
+
+interface TagRepository : ElasticsearchRepository<TagInfo,String> {
+    override fun findById(id: String): Optional<TagInfo>
+    override fun <S : TagInfo?> save(entity: S & Any): S & Any
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,3 +18,9 @@ spring:
           - https://huggingface.co/etri-vilab/Ko-LLaVA-13b/resolve/main/pytorch_model.bin.index.json
       tokenizer:
         uri: https://huggingface.co/etri-vilab/Ko-LLaVA-13b/resolve/main/tokenizer_config.json
+
+# required : 배포 이후 logback을 통해 환경별 세부 관리가 필요함
+logging:
+  level:
+    root: INFO
+

--- a/src/test/kotlin/zzibu/jeho/tagify/repository/BeanTagRepositoryTest.kt
+++ b/src/test/kotlin/zzibu/jeho/tagify/repository/BeanTagRepositoryTest.kt
@@ -20,6 +20,14 @@ class BeanTagRepositoryTest : BehaviorSpec() {
     private lateinit var tagRepository : TagRepository
 
     init {
+        var savedTagId: String? = null
+
+        afterTest {
+            savedTagId?.let {
+                tagRepository.deleteById(it)
+            }
+        }
+
         Given("태그 저장 테스트") {
             val tagInfo = TagInfo(
                 name = "test",
@@ -30,11 +38,13 @@ class BeanTagRepositoryTest : BehaviorSpec() {
             When("태그 정보를 입력하면") {
                 val savedTagInfo = tagRepository.save(tagInfo)
                 logger.info { "TagRepository-save() : $savedTagInfo" }
+
                 Then("저장된 태그 정보를 반환받는다.") {
                     savedTagInfo.id shouldNotBe null
                     // id, uploadDate의 경우 ES에 의해 생성되므로 이를 제외하고 검증
                     savedTagInfo.copy(id = null, uploadDate = null) shouldBe tagInfo
                 }
+                savedTagId = savedTagInfo.id
             }
 
         }
@@ -49,6 +59,7 @@ class BeanTagRepositoryTest : BehaviorSpec() {
                 val savedTagInfo = tagRepository.save(tagInfo)
                 val foundTagInfo = tagRepository.findById(savedTagInfo.id?: "1").get()
                 logger.info { "TagRepository-findById() : $foundTagInfo" }
+
                 Then("저장된 태그 정보를 반환받는다.") {
                     foundTagInfo shouldBe TagInfo(
                         id = savedTagInfo.id,
@@ -58,6 +69,7 @@ class BeanTagRepositoryTest : BehaviorSpec() {
                         uploadDate = foundTagInfo.uploadDate // uploadDate의 경우 auto generated 되므로 임의로 값을 일치시킴.
                     )
                 }
+                savedTagId = savedTagInfo.id
             }
 
             When("존재하지 않는 ID로 태그를 조회하면") {
@@ -70,6 +82,5 @@ class BeanTagRepositoryTest : BehaviorSpec() {
             }
         }
     }
-
     override fun extensions() = listOf(SpringExtension)
 }

--- a/src/test/kotlin/zzibu/jeho/tagify/repository/BeanTagRepositoryTest.kt
+++ b/src/test/kotlin/zzibu/jeho/tagify/repository/BeanTagRepositoryTest.kt
@@ -1,0 +1,75 @@
+package zzibu.jeho.tagify.repository
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.ComponentScan
+import zzibu.jeho.tagify.entity.TagInfo
+
+private val logger = KotlinLogging.logger{}
+
+
+@SpringBootTest
+@ComponentScan(basePackages = ["zzibu.jeho.tagify"])
+class BeanTagRepositoryTest : BehaviorSpec() {
+    @Autowired
+    private lateinit var tagRepository : TagRepository
+
+    init {
+        Given("태그 저장 테스트") {
+            val tagInfo = TagInfo(
+                name = "test",
+                url = "http://example.com/test",
+                owner = "owner",
+            )
+
+            When("태그 정보를 입력하면") {
+                val savedTagInfo = tagRepository.save(tagInfo)
+                logger.info { "TagRepository-save() : $savedTagInfo" }
+                Then("저장된 태그 정보를 반환받는다.") {
+                    savedTagInfo.id shouldNotBe null
+                    // id, uploadDate의 경우 ES에 의해 생성되므로 이를 제외하고 검증
+                    savedTagInfo.copy(id = null, uploadDate = null) shouldBe tagInfo
+                }
+            }
+
+        }
+        Given("태그 조회 테스트") {
+            val tagInfo = TagInfo(
+                name = "test",
+                url = "http://example.com/test",
+                owner = "owner",
+            )
+
+            When("저장된 태그를 ID로 조회하면") {
+                val savedTagInfo = tagRepository.save(tagInfo)
+                val foundTagInfo = tagRepository.findById(savedTagInfo.id?: "1").get()
+                logger.info { "TagRepository-findById() : $foundTagInfo" }
+                Then("저장된 태그 정보를 반환받는다.") {
+                    foundTagInfo shouldBe TagInfo(
+                        id = savedTagInfo.id,
+                        name = savedTagInfo.name,
+                        url = savedTagInfo.url,
+                        owner = savedTagInfo.owner,
+                        uploadDate = foundTagInfo.uploadDate // uploadDate의 경우 auto generated 되므로 임의로 값을 일치시킴.
+                    )
+                }
+            }
+
+            When("존재하지 않는 ID로 태그를 조회하면") {
+                val nonExistentId = "non-existent-id"
+
+                Then("빈 Optional을 반환한다.") {
+                    val result = tagRepository.findById(nonExistentId)
+                    result.isPresent shouldBe false
+                }
+            }
+        }
+    }
+
+    override fun extensions() = listOf(SpringExtension)
+}

--- a/src/test/kotlin/zzibu/jeho/tagify/repository/FakeTagRepository.kt
+++ b/src/test/kotlin/zzibu/jeho/tagify/repository/FakeTagRepository.kt
@@ -1,0 +1,112 @@
+package zzibu.jeho.tagify.repository
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.data.elasticsearch.core.RefreshPolicy
+import zzibu.jeho.tagify.entity.TagInfo
+import java.time.LocalDateTime
+import java.util.*
+import java.util.concurrent.ConcurrentHashMap
+
+class FakeTagRepository : TagRepository{
+    private val storage = ConcurrentHashMap<String, TagInfo>()
+    private var idCounter = 0L;
+
+    // ElasticsearchRepository가 java로 구현되어 TagInfo?가 아닌 Optional을 사용
+    override fun findById(id: String): Optional<TagInfo> {
+        return Optional.ofNullable(storage[id])
+    }
+
+    override fun <S : TagInfo?> save(entity: S & Any): S & Any {
+        val id = entity?.id ?: (++idCounter).toString()
+        val tag = entity!!.copy(id = id, uploadDate = LocalDateTime.now())
+        storage[id] = tag
+        return tag as (S & Any)
+    }
+
+    // ---------------- Not yet implemented ----------------
+
+    override fun findAll(sort: Sort): MutableIterable<TagInfo> {
+        TODO("Not yet implemented")
+    }
+
+    override fun findAll(pageable: Pageable): Page<TagInfo> {
+        TODO("Not yet implemented")
+    }
+
+    override fun findAll(): MutableIterable<TagInfo> {
+        TODO("Not yet implemented")
+    }
+
+    override fun <S : TagInfo?> save(entity: S & Any, refreshPolicy: RefreshPolicy?): S & Any {
+        TODO("Not yet implemented")
+    }
+
+    override fun <S : TagInfo?> saveAll(
+        entities: MutableIterable<S>,
+        refreshPolicy: RefreshPolicy?
+    ): MutableIterable<S> {
+        TODO("Not yet implemented")
+    }
+
+    override fun <S : TagInfo?> saveAll(entities: MutableIterable<S>): MutableIterable<S> {
+        TODO("Not yet implemented")
+    }
+
+    override fun existsById(id: String): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun findAllById(ids: MutableIterable<String>): MutableIterable<TagInfo> {
+        TODO("Not yet implemented")
+    }
+
+    override fun count(): Long {
+        TODO("Not yet implemented")
+    }
+
+    override fun deleteById(id: String, refreshPolicy: RefreshPolicy?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun deleteById(id: String) {
+        TODO("Not yet implemented")
+    }
+
+    override fun delete(entity: TagInfo, refreshPolicy: RefreshPolicy?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun delete(entity: TagInfo) {
+        TODO("Not yet implemented")
+    }
+
+    override fun deleteAllById(ids: MutableIterable<String>, refreshPolicy: RefreshPolicy?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun deleteAllById(ids: MutableIterable<String>) {
+        TODO("Not yet implemented")
+    }
+
+    override fun deleteAll(entities: MutableIterable<TagInfo>, refreshPolicy: RefreshPolicy?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun deleteAll(refreshPolicy: RefreshPolicy?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun deleteAll(entities: MutableIterable<TagInfo>) {
+        TODO("Not yet implemented")
+    }
+
+    override fun deleteAll() {
+        TODO("Not yet implemented")
+    }
+
+    override fun searchSimilar(entity: TagInfo, fields: Array<out String>?, pageable: Pageable): Page<TagInfo> {
+        TODO("Not yet implemented")
+    }
+}

--- a/src/test/kotlin/zzibu/jeho/tagify/repository/FakeTagRepository.kt
+++ b/src/test/kotlin/zzibu/jeho/tagify/repository/FakeTagRepository.kt
@@ -19,8 +19,8 @@ class FakeTagRepository : TagRepository{
     }
 
     override fun <S : TagInfo?> save(entity: S & Any): S & Any {
-        val id = entity?.id ?: (++idCounter).toString()
-        val tag = entity!!.copy(id = id, uploadDate = LocalDateTime.now())
+        val id = entity.id ?: (++idCounter).toString()
+        val tag = entity.copy(id = id, uploadDate = LocalDateTime.now())
         storage[id] = tag
         return tag as (S & Any)
     }

--- a/src/test/kotlin/zzibu/jeho/tagify/repository/TagRepositoryTest.kt
+++ b/src/test/kotlin/zzibu/jeho/tagify/repository/TagRepositoryTest.kt
@@ -1,22 +1,63 @@
 package zzibu.jeho.tagify.repository
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.kotest.core.spec.style.BehaviorSpec
-import java.time.LocalDateTime
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import zzibu.jeho.tagify.entity.TagInfo
 
+private val logger = KotlinLogging.logger{}
 
 class TagRepositoryTest : BehaviorSpec({
+
+    val tagRepository : TagRepository = FakeTagRepository();
+
     Given("태그 저장 테스트") { // id, uploadDate는 ES에서 자동 생성
         val tagInfo = TagInfo(
             name = "test",
             url = "http://example.com/test",
             owner = "owner",
-            updateDate = null,
         )
         When("태그 정보를 입력하면") {
             val savedTagInfo = tagRepository.save(tagInfo)
+            logger.info { "TagRepository-save() : $savedTagInfo" }
+
             Then("저장된 태그 정보를 반환받는다."){
                 savedTagInfo.id shouldNotBe null
-                savedTagInfo.copy(id = null, updateDate = tagInfo.updateDate) shouldBe tagInfo
+                // id, uploadDate의 경우 ES에 의해 생성되므로 이를 제외하고 검증
+                savedTagInfo.copy(id = null, uploadDate = null) shouldBe tagInfo
+            }
+        }
+    }
+    Given("태그 조회 테스트") {
+        val tagInfo = TagInfo(
+            name = "test",
+            url = "http://example.com/test",
+            owner = "owner",
+        )
+
+        When("저장된 태그를 ID로 조회하면") {
+            val savedTagInfo = tagRepository.save(tagInfo)
+            val foundTagInfo = tagRepository.findById(savedTagInfo.id?: "1").get()
+            logger.info { "TagRepository-findById() : $foundTagInfo" }
+
+            Then("저장된 태그 정보를 반환받는다.") {
+                foundTagInfo shouldBe TagInfo(
+                    id = savedTagInfo.id,
+                    name = savedTagInfo.name,
+                    url = savedTagInfo.url,
+                    owner = savedTagInfo.owner,
+                    uploadDate = foundTagInfo.uploadDate // uploadDate의 경우 auto generated 되므로 임의로 값을 일치시킴.
+                )
+            }
+        }
+
+        When("존재하지 않는 ID로 태그를 조회하면") {
+            val nonExistentId = "non-existent-id"
+
+            Then("빈 Optional을 반환한다.") {
+                val result = tagRepository.findById(nonExistentId)
+                result.isPresent shouldBe false
             }
         }
     }

--- a/src/test/kotlin/zzibu/jeho/tagify/repository/TagRepositoryTest.kt
+++ b/src/test/kotlin/zzibu/jeho/tagify/repository/TagRepositoryTest.kt
@@ -1,0 +1,23 @@
+package zzibu.jeho.tagify.repository
+
+import io.kotest.core.spec.style.BehaviorSpec
+import java.time.LocalDateTime
+
+
+class TagRepositoryTest : BehaviorSpec({
+    Given("태그 저장 테스트") { // id, uploadDate는 ES에서 자동 생성
+        val tagInfo = TagInfo(
+            name = "test",
+            url = "http://example.com/test",
+            owner = "owner",
+            updateDate = null,
+        )
+        When("태그 정보를 입력하면") {
+            val savedTagInfo = tagRepository.save(tagInfo)
+            Then("저장된 태그 정보를 반환받는다."){
+                savedTagInfo.id shouldNotBe null
+                savedTagInfo.copy(id = null, updateDate = tagInfo.updateDate) shouldBe tagInfo
+            }
+        }
+    }
+})


### PR DESCRIPTION
## #️⃣연관된 이슈

> related #2 

## 📝작업 내용

> TDD 기반으로 Elasticsearch에 태그 정보 저장 Repository 코드 작성했습니다.
> DB와 연결되는 부분은 테스트 코드에서 FakeRepository로 해결했습니다.

## 💬리뷰 요구사항(선택)

> Repository와 상호작용 하는 데이터 클래스들의 폴더명을 entity로 했는데 domain으로 하는게 나을지 고민 중입니다.
> BeanTagRepositoryTest(bean을 띄워서 테스트 하는 클래스) 코드에서 실제로 저장되지 않도록 afterEach에서 롤백하려고 `savedTagId = savedTagInfo.id` 이거 쓰는데 살짝 별로인거 같아서 고민 중입니다. 😓
```kotlin
var savedTagId: String? = null

        afterTest {
            savedTagId?.let {
                tagRepository.deleteById(it)
            }
        }

        Given("태그 저장 테스트") {
            val tagInfo = TagInfo(
                name = "test",
                url = "http://example.com/test",
                owner = "owner",
            )

            When("태그 정보를 입력하면") {
                val savedTagInfo = tagRepository.save(tagInfo)
                logger.info { "TagRepository-save() : $savedTagInfo" }

                Then("저장된 태그 정보를 반환받는다.") {
                    savedTagInfo.id shouldNotBe null
                    // id, uploadDate의 경우 ES에 의해 생성되므로 이를 제외하고 검증
                    savedTagInfo.copy(id = null, uploadDate = null) shouldBe tagInfo
                }
                savedTagId = savedTagInfo.id
            }

        }
``` 

close : #2 
