### PR TITLE
#17 : OCR 기반 PDF 추론 API 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,6 +45,9 @@ dependencies {
 	// PDFBox
 	implementation("org.apache.pdfbox:pdfbox:2.0.24")
 
+	// Tesseract (OCR Dependency)
+	implementation("net.sourceforge.tess4j:tess4j:5.4.0")
+
 	annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 

--- a/src/main/kotlin/zzibu/jeho/tagify/config/ModelConfig.kt
+++ b/src/main/kotlin/zzibu/jeho/tagify/config/ModelConfig.kt
@@ -12,7 +12,12 @@ import org.springframework.context.annotation.PropertySource
 class ModelConfig(val modelProperties: ModelProperties) {
 
     @Bean
-    fun assistantMessage() : String{
-        return modelProperties.message
+    fun assistantImageMessage() : String{
+        return modelProperties.imageMessage
+    }
+
+    @Bean
+    fun assistantPdfMessage() : String{
+        return modelProperties.pdfMessage
     }
 }

--- a/src/main/kotlin/zzibu/jeho/tagify/config/ModelProperties.kt
+++ b/src/main/kotlin/zzibu/jeho/tagify/config/ModelProperties.kt
@@ -6,5 +6,5 @@ import org.springframework.context.annotation.PropertySource
 import org.springframework.stereotype.Component
 
 @ConfigurationProperties(prefix="vlm")
-data class ModelProperties (val message:String)
+data class ModelProperties (val pdfMessage: String , val imageMessage:String)
 {}

--- a/src/main/kotlin/zzibu/jeho/tagify/controller/TagController.kt
+++ b/src/main/kotlin/zzibu/jeho/tagify/controller/TagController.kt
@@ -34,4 +34,14 @@ class TagController(private val pdfService: PdfService,
             HttpStatus.OK
         )
     }
+
+//    @PostMapping("/pdf/text")
+//    fun generateTagsFromPDF2(
+//        @RequestParam("pdf") pdf: MultipartFile,
+//    ): ResponseEntity<List<String>> {
+//        return ResponseEntity(
+//            pdfService.generateTagFromPDFToText(pdf),
+//            HttpStatus.OK
+//        )
+//    }
 }

--- a/src/main/kotlin/zzibu/jeho/tagify/service/ImageService.kt
+++ b/src/main/kotlin/zzibu/jeho/tagify/service/ImageService.kt
@@ -19,7 +19,7 @@ import java.util.List
 @Service
 class ImageService(
     private val chatModel: ChatModel,
-    private val assistantMessage: String,
+    private val assistantImageMessage: String,
     private val maxFileSize: Long
     ) {
 
@@ -35,7 +35,7 @@ class ImageService(
         val imageData = ConversionUtils.convertToInputStreamResource(image)
 
         val userMessage = UserMessage(
-            assistantMessage,
+            assistantImageMessage,
             List.of<Media>(Media(MimeTypeUtils.ALL, imageData))
         )
 

--- a/src/main/kotlin/zzibu/jeho/tagify/service/PdfService.kt
+++ b/src/main/kotlin/zzibu/jeho/tagify/service/PdfService.kt
@@ -22,7 +22,7 @@ private val logger = KotlinLogging.logger{}
 @Service
 class PdfService(
     private val chatModel: ChatModel,
-    private val assistantMessage: String,
+    private val assistantPdfMessage: String,
     private val maxFileSize: Long
     ) {
 
@@ -35,12 +35,31 @@ class PdfService(
         }
         return tags
     }
+
+    fun generateTagFromPDFToText(file: MultipartFile): List<String> {
+        validateFile(file)
+        val ocrTexts = ConversionUtils.convertFileToText(file)
+        logger.error { ocrTexts }
+        val vlmResponse = sendTextToVLM(ocrTexts)
+        val tags = ConversionUtils.jsonToList(vlmResponse)
+
+        return tags
+    }
     fun sendImageToVLM(image: BufferedImage): String {
         val imageData = ConversionUtils.convertToInputStreamResource(image)
         val userMessage = UserMessage(
-            assistantMessage,
+            assistantPdfMessage,
             listOf<Media>(Media(MimeTypeUtils.ALL, imageData))
         )
+
+        val response: ChatResponse = chatModel.call(
+            Prompt(listOf(userMessage), OllamaOptions.create().withModel("llava"))
+        )
+        return response.result.output.content.trimIndent()
+    }
+
+    fun sendTextToVLM(text: String): String {
+        val userMessage = UserMessage(assistantPdfMessage)
 
         val response: ChatResponse = chatModel.call(
             Prompt(listOf(userMessage), OllamaOptions.create().withModel("llava"))

--- a/src/main/kotlin/zzibu/jeho/tagify/service/PdfService.kt
+++ b/src/main/kotlin/zzibu/jeho/tagify/service/PdfService.kt
@@ -39,7 +39,7 @@ class PdfService(
     fun generateTagFromPDFToText(file: MultipartFile): List<String> {
         validateFile(file)
         val ocrTexts = ConversionUtils.convertFileToText(file)
-        logger.error { ocrTexts }
+
         val vlmResponse = sendTextToVLM(ocrTexts)
         val tags = ConversionUtils.jsonToList(vlmResponse)
 

--- a/src/main/kotlin/zzibu/jeho/tagify/util/ConversionUtils.kt
+++ b/src/main/kotlin/zzibu/jeho/tagify/util/ConversionUtils.kt
@@ -2,6 +2,8 @@ package zzibu.jeho.tagify.util
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import net.sourceforge.tess4j.Tesseract
+import net.sourceforge.tess4j.TesseractException
 import org.apache.pdfbox.pdmodel.PDDocument
 import org.apache.pdfbox.rendering.PDFRenderer
 import org.springframework.core.io.InputStreamResource
@@ -66,5 +68,24 @@ object ConversionUtils {
         }
         document.close()
         return images
+    }
+
+    @Throws(TesseractException::class)
+    fun extractTextFromImage(image: BufferedImage): String {
+        val tesseract = Tesseract()
+        tesseract.setDatapath("data/tessdata") // Tesseract 데이터 파일 경로
+        tesseract.setLanguage("eng") // 사용할 언어 설정
+        return tesseract.doOCR(image)
+    }
+
+    @Throws(IOException::class, TesseractException::class)
+    fun convertFileToText(file: MultipartFile): String {
+        val images = convertFileToImages(file)
+        val textBuilder = StringBuilder()
+        for (image in images) {
+            textBuilder.append(extractTextFromImage(image))
+            textBuilder.append("\n")
+        }
+        return textBuilder.toString()
     }
 }

--- a/src/main/resources/model.properties
+++ b/src/main/resources/model.properties
@@ -1,2 +1,6 @@
-vlm.message=Look at the image and list the words that come to mind in an array \
-format : [1 : "tag1", 2: "tag2", 3: "tag3", 4: "tag4", 5: "tag5"] 
+vlm.pdf-message=Identify the pdf-converted text and return the emerging tag to the array \
+format : [1 : "tag1", 2: "tag2", 3: "tag3", 4: "tag4", 5: "tag5"]  \
+  
+
+vlm.image-message=Look at the image and list the words that come to mind in an array \
+format : [1 : "tag1", 2: "tag2", 3: "tag3", 4: "tag4", 5: "tag5"]  


### PR DESCRIPTION
## #️⃣연관된 이슈

- related #17 

## 📝작업 내용

- #1 에서 개발한 API의 경우 PDF -> Image -> VLM 방식이었으나, #17에선 PDF -> Image -> Text(By OCR) -> VLM 방식으로 변경되었습니다.
- 그러나 VLM의 이미지 식별 기능이 좋아서 그런지 OCR을 통해 Text로 변환하는 과정에 데이터의 부정확성이 높아진 것으로 파악됩니다.
- 그래서 굳이 OCR을 통해 Text로 변환하지 않고 #1에서 변환하는 방식을 우선 그대로 사용하는 것이 좋을 것 같습니다!

### 스크린샷 (선택)
| ![image](https://github.com/ZZIBU/Tagify/assets/78259314/efa6086d-abe7-4e74-aad3-810240dea43b) | ![image](https://github.com/ZZIBU/Tagify/assets/78259314/77306c51-e776-41cd-9d25-09b6be4ca7e8) |
|---|---|
| 기존 PDF 이미지 | OCR 변환 텍스트 |

- 추가로 OCR trainedData 데이터가 eng, ko, jp 등 언어에 따라 존재한다는 점도 전달드립니다. (여러 언어가 섞인 경우 잘 동작 안하는 듯 합니다. 위 스크린샷에선 eng.trainedData를 썼는데 한글은 식별이 안됨)
- 일부 부정확 데이터 예시
  - jhl81094 -> jhI81094
  - jhl8109 -> jhig109 
  - ...

- closed #17